### PR TITLE
Fix/remove urgency field

### DIFF
--- a/card-creator.code-workspace
+++ b/card-creator.code-workspace
@@ -1,0 +1,10 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+    ],
+    "settings": {
+        "editor.formatOnSave": false
+    }
+}

--- a/src/components/CardEditorPanel.tsx
+++ b/src/components/CardEditorPanel.tsx
@@ -121,11 +121,6 @@ export const CardEditorCore: React.FunctionComponent<Props> = ({
                         onChange={(_, option) => option && updateCard({type: cardTypeMap.find(([key, _]) => option.key === key)![1]})}
                         options={cardTypeMap.map(([key, _]) => ({key: key, text: key}))}
                     />
-                    <Dropdown
-                        label="Urgency"
-                        placeholder="Action Urgency"
-                        options={["High", "Medium", "Low"].map(t => ({key: t, text: t}))}
-                    />
                     <LazyTextField label="Location" value={card.location} onChange={(_: any, value?: string) => value !== undefined && updateCard({location: value})}/>
                     <LazyTextField
                         label="Text"


### PR DESCRIPTION
Also added the workspace file to prevent formatting problems.

When using live share sessions, make sure to open the workspace file instead of the folder directly. This will automatically disable formatting for all session participants, preventing diff changes caused by formatters like prettier.

Resolves #15 